### PR TITLE
Add delete confirmation modal

### DIFF
--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -11,6 +11,7 @@ import {BrowserModule} from "@angular/platform-browser";
 import {provideHttpClient} from "@angular/common/http";
 import {BrowserAnimationsModule} from "@angular/platform-browser/animations";
 import {AddCompanyComponent} from "./dialog/add-company/add-company.component";
+import {ConfirmDeleteComponent} from "./dialog/confirm-delete/confirm-delete.component";
 import {MatDialogActions, MatDialogClose, MatDialogContent, MatDialogTitle} from "@angular/material/dialog";
 import {MatFormField, MatLabel} from "@angular/material/form-field";
 import {FormsModule, ReactiveFormsModule} from "@angular/forms";
@@ -21,7 +22,8 @@ import {MatInput} from "@angular/material/input";
   declarations: [
     AppComponent,
     CompanyListComponent,
-    AddCompanyComponent
+    AddCompanyComponent,
+    ConfirmDeleteComponent,
   ],
   imports: [
     CommonModule,

--- a/frontend/src/app/company-list/company-list.component.html
+++ b/frontend/src/app/company-list/company-list.component.html
@@ -10,7 +10,7 @@
       <mat-list-item *ngFor="let company of companies">
         <div class="company-item">
           <span>{{ company.name }}</span>
-          <button mat-mini-fab color="warn" class="delete-btn" (click)="deleteCompany(company.id)" aria-label="Delete company">
+          <button mat-mini-fab color="warn" class="delete-btn" (click)="openDeleteDialog(company.id)" aria-label="Delete company">
             <mat-icon>delete</mat-icon>
           </button>
         </div>

--- a/frontend/src/app/company-list/company-list.component.ts
+++ b/frontend/src/app/company-list/company-list.component.ts
@@ -6,6 +6,7 @@ import {MatDialog} from "@angular/material/dialog";
 import {AddCompanyComponent} from "../dialog/add-company/add-company.component";
 
 
+import {ConfirmDeleteComponent} from "../dialog/confirm-delete/confirm-delete.component";
 @Component({
   selector: 'app-company-list',
   templateUrl: './company-list.component.html',
@@ -57,6 +58,15 @@ export class CompanyListComponent implements OnInit {
       }
     });
   }
+  openDeleteDialog(id: string): void {
+    const dialogRef = this.dialog.open(ConfirmDeleteComponent);
+    dialogRef.afterClosed().subscribe(result => {
+      if (result) {
+        this.deleteCompany(id);
+      }
+    });
+  }
+
 
   deleteCompany(id: string): void {
     this.companyService.deleteCompany(id).subscribe(() => {

--- a/frontend/src/app/dialog/confirm-delete/confirm-delete.component.css
+++ b/frontend/src/app/dialog/confirm-delete/confirm-delete.component.css
@@ -1,0 +1,1 @@
+/* empty styles for confirm delete dialog */

--- a/frontend/src/app/dialog/confirm-delete/confirm-delete.component.html
+++ b/frontend/src/app/dialog/confirm-delete/confirm-delete.component.html
@@ -1,0 +1,5 @@
+<h1 mat-dialog-title>Are you sure you want to delete this company?</h1>
+<div mat-dialog-actions>
+  <button mat-button (click)="onNo()">No</button>
+  <button mat-button color="warn" (click)="onYes()">Yes</button>
+</div>

--- a/frontend/src/app/dialog/confirm-delete/confirm-delete.component.ts
+++ b/frontend/src/app/dialog/confirm-delete/confirm-delete.component.ts
@@ -1,0 +1,19 @@
+import { Component } from '@angular/core';
+import { MatDialogRef } from '@angular/material/dialog';
+
+@Component({
+  selector: 'app-confirm-delete',
+  templateUrl: './confirm-delete.component.html',
+  styleUrl: './confirm-delete.component.css'
+})
+export class ConfirmDeleteComponent {
+  constructor(private dialogRef: MatDialogRef<ConfirmDeleteComponent>) {}
+
+  onYes(): void {
+    this.dialogRef.close(true);
+  }
+
+  onNo(): void {
+    this.dialogRef.close(false);
+  }
+}


### PR DESCRIPTION
## Summary
- add a confirmation dialog component for deleting companies
- update company list to open the dialog before deleting
- register the dialog component in the app module

## Testing
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_68402f4829008327aa9c7bc3245fc25d