### PR TITLE
Implement company edit modal

### DIFF
--- a/backend/src/main/java/com/example/springcrudapp/controller/CompanyController.java
+++ b/backend/src/main/java/com/example/springcrudapp/controller/CompanyController.java
@@ -30,6 +30,11 @@ public class CompanyController {
         return companyService.count();
     }
 
+    @GetMapping("/getDetails")
+    public Company getDetails(@RequestParam UUID id) {
+        return companyService.findById(id);
+    }
+
     @PostMapping("/add")
     @ResponseStatus(HttpStatus.CREATED)
     public Company add(@RequestBody CompanyDTO companyDTO) {

--- a/backend/src/main/java/com/example/springcrudapp/service/CompanyService.java
+++ b/backend/src/main/java/com/example/springcrudapp/service/CompanyService.java
@@ -36,6 +36,10 @@ public class CompanyService {
         return companyRepository.count();
     }
 
+    public Company findById(UUID id) {
+        return companyRepository.findById(id).orElseThrow(CompanyNotFound::new);
+    }
+
     public Company save(CompanyDTO companyDto) {
         return companyRepository.save(new Company(companyDto));
     }

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -11,6 +11,7 @@ import {BrowserModule} from "@angular/platform-browser";
 import {provideHttpClient} from "@angular/common/http";
 import {BrowserAnimationsModule} from "@angular/platform-browser/animations";
 import {AddCompanyComponent} from "./dialog/add-company/add-company.component";
+import {EditCompanyComponent} from "./dialog/edit-company/edit-company.component";
 import {ConfirmDeleteComponent} from "./dialog/confirm-delete/confirm-delete.component";
 import {MatDialogActions, MatDialogClose, MatDialogContent, MatDialogTitle} from "@angular/material/dialog";
 import {MatFormField, MatLabel} from "@angular/material/form-field";
@@ -23,6 +24,7 @@ import {MatInput} from "@angular/material/input";
     AppComponent,
     CompanyListComponent,
     AddCompanyComponent,
+    EditCompanyComponent,
     ConfirmDeleteComponent,
   ],
   imports: [

--- a/frontend/src/app/company-list/company-list.component.css
+++ b/frontend/src/app/company-list/company-list.component.css
@@ -34,3 +34,7 @@
 .delete-btn:hover {
   background-color: #d32f2f; /* slightly darker red */
 }
+
+.company-name:hover {
+  cursor: pointer;
+}

--- a/frontend/src/app/company-list/company-list.component.html
+++ b/frontend/src/app/company-list/company-list.component.html
@@ -9,7 +9,7 @@
     <mat-list class="mat-body-1" role="list">
       <mat-list-item *ngFor="let company of companies" (click)="openEditDialog(company.id)">
         <div class="company-item">
-          <span>{{ company.name }}</span>
+          <span class="company-name">{{ company.name }}</span>
           <button mat-mini-fab color="warn" class="delete-btn" (click)="openDeleteDialog(company.id); $event.stopPropagation()" aria-label="Delete company">
             <mat-icon>delete</mat-icon>
           </button>

--- a/frontend/src/app/company-list/company-list.component.html
+++ b/frontend/src/app/company-list/company-list.component.html
@@ -7,10 +7,10 @@
   </div>
   <div>
     <mat-list class="mat-body-1" role="list">
-      <mat-list-item *ngFor="let company of companies">
+      <mat-list-item *ngFor="let company of companies" (click)="openEditDialog(company.id)">
         <div class="company-item">
           <span>{{ company.name }}</span>
-          <button mat-mini-fab color="warn" class="delete-btn" (click)="openDeleteDialog(company.id)" aria-label="Delete company">
+          <button mat-mini-fab color="warn" class="delete-btn" (click)="openDeleteDialog(company.id); $event.stopPropagation()" aria-label="Delete company">
             <mat-icon>delete</mat-icon>
           </button>
         </div>

--- a/frontend/src/app/company-list/company-list.component.ts
+++ b/frontend/src/app/company-list/company-list.component.ts
@@ -5,6 +5,8 @@ import {PageEvent} from "@angular/material/paginator";
 import {MatDialog} from "@angular/material/dialog";
 import {AddCompanyComponent} from "../dialog/add-company/add-company.component";
 
+import {EditCompanyComponent} from "../dialog/edit-company/edit-company.component";
+
 
 import {ConfirmDeleteComponent} from "../dialog/confirm-delete/confirm-delete.component";
 @Component({
@@ -55,6 +57,15 @@ export class CompanyListComponent implements OnInit {
             this.length = data;
           }
         );
+      }
+    });
+  }
+
+  openEditDialog(id: string): void {
+    const dialogRef = this.dialog.open(EditCompanyComponent, {data: {id}});
+    dialogRef.afterClosed().subscribe(result => {
+      if (result) {
+        this.getCompanies();
       }
     });
   }

--- a/frontend/src/app/dialog/edit-company/edit-company.component.css
+++ b/frontend/src/app/dialog/edit-company/edit-company.component.css
@@ -1,0 +1,5 @@
+.form-group {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}

--- a/frontend/src/app/dialog/edit-company/edit-company.component.html
+++ b/frontend/src/app/dialog/edit-company/edit-company.component.html
@@ -1,0 +1,29 @@
+<h1 mat-dialog-title>Edit company</h1>
+<div mat-dialog-content>
+  <form [formGroup]="form" class="form-group">
+    <mat-form-field>
+      <mat-label>Name</mat-label>
+      <input matInput formControlName="name">
+    </mat-form-field>
+    <mat-form-field>
+      <mat-label>Street</mat-label>
+      <input matInput formControlName="street">
+    </mat-form-field>
+    <mat-form-field>
+      <mat-label>Postal code</mat-label>
+      <input matInput formControlName="postalCode">
+    </mat-form-field>
+    <mat-form-field>
+      <mat-label>Building number</mat-label>
+      <input matInput formControlName="buildingNumber">
+    </mat-form-field>
+    <mat-form-field>
+      <mat-label>House number</mat-label>
+      <input matInput formControlName="houseNumber">
+    </mat-form-field>
+  </form>
+</div>
+<div mat-dialog-actions>
+  <button mat-button (click)="onCancel()">Cancel</button>
+  <button mat-button (click)="onSubmit()">Save</button>
+</div>

--- a/frontend/src/app/dialog/edit-company/edit-company.component.ts
+++ b/frontend/src/app/dialog/edit-company/edit-company.component.ts
@@ -1,0 +1,67 @@
+import {Component, Inject, OnInit} from '@angular/core';
+import {MAT_DIALOG_DATA, MatDialogRef} from "@angular/material/dialog";
+import {FormBuilder, FormGroup, Validators} from "@angular/forms";
+import {CompanyService} from "../../service/company.service";
+import {AddressDto} from "../../model/address-dto";
+import {CompanyDto} from "../../model/company-dto";
+import {CompanyDetailsDto} from "../../model/company-details-dto";
+
+@Component({
+  selector: 'app-edit-company',
+  templateUrl: './edit-company.component.html',
+  styleUrl: './edit-company.component.css'
+})
+export class EditCompanyComponent implements OnInit {
+  form: FormGroup;
+
+  constructor(
+    private formBuilder: FormBuilder,
+    private dialogRef: MatDialogRef<EditCompanyComponent>,
+    private companyService: CompanyService,
+    @Inject(MAT_DIALOG_DATA) public data: {id: string}
+  ) {
+    this.form = this.formBuilder.group({
+      name: ['', Validators.required],
+      street: [''],
+      postalCode: [''],
+      buildingNumber: [''],
+      houseNumber: [''],
+    });
+  }
+
+  ngOnInit(): void {
+    this.companyService.getCompanyDetails(this.data.id).subscribe((company: CompanyDetailsDto) => {
+      this.form.patchValue({
+        name: company.name,
+        street: company.address?.street ?? '',
+        postalCode: company.address?.postalCode ?? '',
+        buildingNumber: company.address?.buildingNumber ?? '',
+        houseNumber: company.address?.houseNumber ?? ''
+      });
+    });
+  }
+
+  onCancel(): void {
+    this.dialogRef.close();
+  }
+
+  onSubmit(): void {
+    if (this.form.valid) {
+      const addressDto: AddressDto = {
+        street: this.form.value.street,
+        postalCode: this.form.value.postalCode,
+        buildingNumber: this.form.value.buildingNumber,
+        houseNumber: this.form.value.houseNumber
+      };
+      const company: CompanyDto = {
+        name: this.form.value.name,
+        addressDto: addressDto
+      };
+      this.companyService.updateCompany(this.data.id, company).subscribe(response => {
+        this.dialogRef.close(response);
+      }, error => {
+        console.error('Error updating company', error);
+      });
+    }
+  }
+}

--- a/frontend/src/app/model/company-details-dto.ts
+++ b/frontend/src/app/model/company-details-dto.ts
@@ -1,0 +1,7 @@
+import {AddressDto} from "./address-dto";
+
+export interface CompanyDetailsDto {
+  id: string;
+  name: string;
+  address: AddressDto | null;
+}

--- a/frontend/src/app/service/company.service.ts
+++ b/frontend/src/app/service/company.service.ts
@@ -3,6 +3,7 @@ import {CompanyListEntryDto} from "../model/company-list-entry-dto";
 import {Observable} from "rxjs";
 import {HttpClient} from "@angular/common/http";
 import {CompanyDto} from "../model/company-dto";
+import {CompanyDetailsDto} from "../model/company-details-dto";
 
 @Injectable({
   providedIn: 'root'
@@ -22,6 +23,14 @@ export class CompanyService {
 
   createCompany(company: CompanyDto): Observable<CompanyDto> {
     return this.http.post<CompanyDto>(this.apiUrl + '/add', company);
+  }
+
+  getCompanyDetails(id: string): Observable<CompanyDetailsDto> {
+    return this.http.get<CompanyDetailsDto>(`${this.apiUrl}/getDetails?id=${id}`);
+  }
+
+  updateCompany(id: string, company: CompanyDto): Observable<CompanyDto> {
+    return this.http.put<CompanyDto>(`${this.apiUrl}/update?id=${id}`, company);
   }
 
   deleteCompany(id: string): Observable<void> {


### PR DESCRIPTION
## Summary
- implement `findById` method in backend service
- expose `/company/getDetails` endpoint
- add frontend `CompanyDetailsDto`
- add `getCompanyDetails` and `updateCompany` methods in company service
- create `EditCompanyComponent` dialog and integrate into app
- open edit dialog when clicking on a company in the list

## Testing
- `npx ng test --watch=false` *(fails: ng not found)*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68403177fd1c8327bbab7e0335aa6e56