### PR TITLE
Fix address fields handling

### DIFF
--- a/backend/src/main/java/com/example/springcrudapp/model/Address.java
+++ b/backend/src/main/java/com/example/springcrudapp/model/Address.java
@@ -33,10 +33,14 @@ public class Address {
 
     public Address(AddressDTO addressDTO) {
         if (addressDTO != null) {
-            street = addressDTO.getStreet();
-            postalCode = addressDTO.getPostalCode();
-            buildingNumber = addressDTO.getBuildingNumber();;
-            houseNumber = addressDTO.getHouseNumber();;
+            street = blankToNull(addressDTO.getStreet());
+            postalCode = blankToNull(addressDTO.getPostalCode());
+            buildingNumber = blankToNull(addressDTO.getBuildingNumber());
+            houseNumber = blankToNull(addressDTO.getHouseNumber());
         }
+    }
+
+    private String blankToNull(String value) {
+        return (value == null || value.isBlank()) ? null : value;
     }
 }

--- a/backend/src/main/java/com/example/springcrudapp/service/CompanyService.java
+++ b/backend/src/main/java/com/example/springcrudapp/service/CompanyService.java
@@ -68,11 +68,15 @@ public class CompanyService {
         }
 
         if (updatedAddress != null) {
-            address.setStreet(updatedAddress.getStreet());
-            address.setPostalCode(updatedAddress.getPostalCode());
-            address.setBuildingNumber(updatedAddress.getBuildingNumber());
-            address.setHouseNumber(updatedAddress.getHouseNumber());
+            address.setStreet(blankToNull(updatedAddress.getStreet()));
+            address.setPostalCode(blankToNull(updatedAddress.getPostalCode()));
+            address.setBuildingNumber(blankToNull(updatedAddress.getBuildingNumber()));
+            address.setHouseNumber(blankToNull(updatedAddress.getHouseNumber()));
         }
+    }
+
+    private String blankToNull(String value) {
+        return (value == null || value.isBlank()) ? null : value;
     }
 
 }

--- a/frontend/src/app/dialog/add-company/add-company.component.ts
+++ b/frontend/src/app/dialog/add-company/add-company.component.ts
@@ -34,10 +34,10 @@ export class AddCompanyComponent {
   onSubmit(): void {
     if (this.form.valid) {
       const address: AddressDto = {
-        street: this.form.value.street,
-        postalCode: this.form.value.postalCode,
-        buildingNumber: this.form.value.buildingNumber,
-        houseNumber: this.form.value.houseNumber
+        street: this.form.value.street || null,
+        postalCode: this.form.value.postalCode || null,
+        buildingNumber: this.form.value.buildingNumber || null,
+        houseNumber: this.form.value.houseNumber || null
       };
       const company: CompanyDto = {
         name: this.form.value.name,

--- a/frontend/src/app/dialog/edit-company/edit-company.component.ts
+++ b/frontend/src/app/dialog/edit-company/edit-company.component.ts
@@ -48,10 +48,10 @@ export class EditCompanyComponent implements OnInit {
   onSubmit(): void {
     if (this.form.valid) {
       const address: AddressDto = {
-        street: this.form.value.street,
-        postalCode: this.form.value.postalCode,
-        buildingNumber: this.form.value.buildingNumber,
-        houseNumber: this.form.value.houseNumber
+        street: this.form.value.street || null,
+        postalCode: this.form.value.postalCode || null,
+        buildingNumber: this.form.value.buildingNumber || null,
+        houseNumber: this.form.value.houseNumber || null
       };
       const company: CompanyDto = {
         name: this.form.value.name,

--- a/frontend/src/app/model/address-dto.ts
+++ b/frontend/src/app/model/address-dto.ts
@@ -1,6 +1,6 @@
 export interface AddressDto {
-  street: string,
-  postalCode: string,
-  buildingNumber: string,
-  houseNumber: string
+  street: string | null,
+  postalCode: string | null,
+  buildingNumber: string | null,
+  houseNumber: string | null
 }


### PR DESCRIPTION
## Summary
- send `null` instead of empty strings for missing address fields
- handle blank strings on backend when creating or updating a company

## Testing
- `bash mvnw -q test` *(fails: Network is unreachable)*
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_68403b945a248327b49c51e31c1abe6c